### PR TITLE
fix: exit 0 with empty output when no files are provided

### DIFF
--- a/scripts/parse_file_list_for_projects.sh
+++ b/scripts/parse_file_list_for_projects.sh
@@ -9,8 +9,7 @@
 INPUT="$(cat)"
 
 if [ "$INPUT" == "" ]; then
-  echo "You must provide a list of files"
-  exit 1
+  exit 0
 fi
 
 if [ "$GIT_CMD" == "" ]; then


### PR DESCRIPTION
## Problem

When a PR only deletes files, `tj-actions/changed-files` returns nothing in `all_changed_files` (deletions are excluded by default). This produces empty input to `parse_file_list_for_projects.sh`, which was exiting with code 1.

## Fix

Changed the empty-input guard to `exit 0` — no files to process means no projects to build, which is valid (not an error).

## Reproducer

PR [robaone/source#323](https://github.com/robaone/source/pull/323) fails because it only deletes `projects/ai-prompts/claude/skills/swan-peer-review-needs-review/SKILL.md`.